### PR TITLE
Docs: fixed docs requirement package

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,5 +1,6 @@
 mkdocs==1.5.3
 mkdocs-material==9.4.6
 mkdocstrings[python]==0.23.0
+mkdocs-autorefs<1.4
 pymdown-extensions==10.3.1
 jupytext==1.15.2


### PR DESCRIPTION
# Description
Previously the `mkdocs-autorefs` package version was not specified within `requirements_docs.txt` and it was pulling in the incorrect version and was incompatible with the rest of the requirements. This should fix the issue, and the code going forward should be able to easily build documentation and deploy it.

## Changes

## Known Issues

## Notes

## Checklist

- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [ ] I have updated the documentation to reflect my changes.
- [ ] My code changes have been verified by automated tests and pass all relevant test scenarios.
