### PR TITLE
Fixed incorrect link for `Internal Wiki Documentation` to point to this repositories wiki instead of the original repository

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,7 @@ nav:
       - API Exceptions: exceptions/api_exceptions.md
       - Node Exceptions: exceptions/node_exceptions.md
   - FAQ: faq.md
-  - Internal Wiki Documentation: https://github.com/C-Accel-CRIPT/Python-SDK/wiki
+  - Internal Wiki Documentation: https://github.com/nh916/Python-SDK/wiki
   - CRIPT Python SDK Discussions: https://github.com/C-Accel-CRIPT/Python-SDK/discussions
 
 theme:


### PR DESCRIPTION
# Description
Fixed incorrect link for `Internal Wiki Documentation` to point to this repositories wiki instead of the original repository
fixed the issue with the link pointing to the old internal docs, and instead it'll point to my own repository internal docs

## Changes

## Known Issues

## Notes

## Checklist

- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
- [x] I have updated the documentation to reflect my changes.
- [ ] My code changes have been verified by automated tests and pass all relevant test scenarios.
